### PR TITLE
Upgrading workshop to 2.0; resolving critical security issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5248,6 +5248,7 @@ dependencies = [
  "frame-executive 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
+ "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pallet-aura 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ git clone https://github.com/substrate-developer-hub/utxo-workshop.git
 
 ## UI Demo
 
-In this UI demo, you will interact with the UTXO blockchain via the [Polkadot UI](https://substrate.dev/docs/en/development/front-end/polkadot-js).
+In this UI demo, you will interact with the UTXO blockchain via the [Polkadot UI](https://substrate.dev/docs/en/development/front-end/polkadot-js). 
+
+The following demo takes you through a scenario where `Alice sends Bob a UTXO with value 50` from her original UTXO (value 100) that she already had during genesis: 
 
 
 1. Compile and build a release in dev mode
@@ -61,17 +63,15 @@ cargo build --release
 ./target/release/utxo-workshop purge-chain --dev
 ```
 
-3. In the console, notice the following helper printouts. In particular, notice a seed account `Alice` was already seeded with `100 UTXO` upon the genesis block. 
-
-Notice we've printed out a few more helper hashes for you, including the transaction encoding for if `Alice were to send Bob 50 UTXO`.
+3. In the console, notice the following helper printouts. In particular, notice the default account `Alice` was already has `100 UTXO` upon the genesis block.
 
 ```zsh
-TODO put printouts here
+
 ```
 
-4. Open [Polkadot JS](https://polkadot.js.org/apps/#/settings). Make sure the client is connected to your local node by going to Settings > General, and selecting `Local Node` in the `remote node` dropdown.
+4. Open [Polkadot JS](https://polkadot.js.org/apps/#/settings), making sure the client is connected to your local node by going to Settings > General, and selecting `Local Node` in the `remote node` dropdown.
 
-5. This UTXO project defines custom datatypes that the JS client cannot infer. Define the custom types in PolkadotJS by going to Settings > Developer tab and paste in the following JSON:
+5. **Declare the custom datatypes in PolkadotJS**, since the JS client cannot authomatically infer this from the UTXO module. Go to Settings > Developer tab and paste in the following JSON:
 
 ```json
 {
@@ -91,18 +91,23 @@ TODO put printouts here
 }
 ```
 
-6. **Check that Alice already has 100 UTXO at genesis**. In `Chain State` > `Storage`, select `utxoModule`. Input the hash `xxxx`. Click the `+` notation to query blockchain state.
+6. **Check that Alice already has 100 UTXO at genesis**. In `Chain State` > `Storage`, select `utxoModule`. Input the hash `0x76584168d10a20084082ed80ec71e2a783abbb8dd6eb9d4893b089228498e9ff`. Click the `+` notation to query blockchain state.
 
 Verify that: 
- - UTXO value is `100`
- - The pubkey indeed belongs to Alice (which is a default, hardcoded account). You use the [subkey](https://substrate.dev/docs/en/next/development/tools/subkey#well-known-keys) tool to confirm that the pubkey indeed belongs to Alice
+ - This UTXO has a value of `100`
+ - This UTXO belongs to Alice's pubkey. You use the [subkey](https://substrate.dev/docs/en/next/development/tools/subkey#well-known-keys) tool to confirm that the pubkey indeed belongs to Alice
 
-7. **Spend Alice's UTXO, giving 50 to Bob.** In the `Extrinsics` tab, invoke the `spend` function from the `utxoModule`, using Alice as the transaction sender. Submit the following transaction hash `TODO` in which Alice sends Bob 50 utxo, burning the remaining amout. 
+7. **Spend Alice's UTXO, giving 50 to Bob.** In the `Extrinsics` tab, invoke the `spend` function from the `utxoModule`, using Alice as the transaction sender. Use the following input parameters:
 
-8. **Verify that your transaction succeeded**. In `Chain State`, look up the following UTXO hash: `TODO`.
-Also verify that the genesis utxo has been spent and no longer exists. 
+- outpoint: `0x76584168d10a20084082ed80ec71e2a783abbb8dd6eb9d4893b089228498e9ff`
+- sigscript: `0x6ceab99702c60b111c12c2867679c5555c00dcd4d6ab40efa01e3a65083bfb6c6f5c1ed3356d7141ec61894153b8ba7fb413bf1e990ed99ff6dee5da1b24fd83`
+- value: `50`
+- pubkey: `0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48`
+```
 
-Coming soon: A video walkthrough of the above. 
+8. **Verify that your transaction succeeded**. In `Chain State`, look up the UTXO hash: `0xdbc75ab8ee9b83dcbcea4695f9c42754d94e92c3c397d63b1bc627c2a2ef94e6` to verify that a new UTXO of 50, belonging to Bob, now exists! Also you can verify that the genesis utxo has been spent and no longer exists in UtxoStore. 
+
+Coming soon: A video walkthrough of the above demo.
 
 ## Beginner Workshop
 **Estimated time**: 2 hours

--- a/README.md
+++ b/README.md
@@ -1,32 +1,24 @@
 # UTXO on Substrate
 
-A UTXO chain implementation on Substrate. This repo is an updated implementation of the original [Substrate UXTO](https://github.com/0x7CFE/substrate-node-template/tree/utxo) by [Dmitriy Kashitsyn](https://github.com/0x7CFE).
+A UTXO chain implementation on Substrate, with two self guided workshops.Original [UXTO inspiration](https://github.com/0x7CFE/substrate-node-template/tree/utxo) by [Dmitriy Kashitsyn](https://github.com/0x7CFE).
 
-For a high-level overview of the code, see the [official blog post](https://www.parity.io/utxo-on-substrate/) by Dmitriy. For a live demo, check out how to set up this repo with [Polkadot UI here](#Demo-Polkadot-UI).
+Substrate Version: `pre-v2.0`. For educational purposes only. 
 
-*Caveat: this implementation is being security reviewed and has outstanding issues. Do not use this implementation in production. It is for educational purposes only!*
+## Table of Contents
+- [Installation](#Installation): Setting up Rust & Substrate dependencies
 
-Please note that the code in this repository was upgraded to Substrate pre-v2.0 in January, 2020.
+- [UI Demo](#UI-Demo): Demoing this UTXO implementation in a simple UI
 
-## Project Structure
-- `master` branch contains the full solution (cheats).
-- `workshop` branch contains a UTXO boilerplate for the following workshop. The following tutorials will walk you through an implementation of UTXO on Substrate in workshop format. Feel free to host your own workshops in your local communities using this boilerplate!
+- [Beginner Workshop](#Beginner-Workshop): A self guided, 1 hour workshop that familiarizes you with Substrate basics
 
-## Workshop
+- [Advanced Workshop](#Advanced-Workshop): A self guided, 2 hour video tutorial, that teaches you how to build this UTXO blockchain from scratch
 
-**Estimated time**: 2 hours
+- [Helpful Resources](#Helpful-Resources): Documentation and references if you get stuck in the workshops
 
-Over this course of this workshop, you will learn:
-- How to implement the UTXO model on Substrate
-- How to secure UTXO transactions against attacks
-- How to seed genesis block with UTXOs
-- How to reward block validators in this environment
-- How to customize transaction pool logic on Substrate
-- Good coding patterns for working with Substrate & Rust
 
-> Note: This branch contains all the answers. Try not to peek!
+## Installation
 
-### 1. Install | Upgrade Rust
+### 1. Install or update Rust
 ```zsh
 curl https://sh.rustup.rs -sSf | sh
 
@@ -38,20 +30,22 @@ rustup target add wasm32-unknown-unknown --toolchain nightly
 rustup update stable
 cargo install --git https://github.com/alexcrichton/wasm-gc
 ```
-### Fork the workshop boilerplate
 
-Fork the workshop to create your own copy of it in your GitHub repository.
-Go https://github.com/substrate-developer-hub/utxo-workshop/fork and choose your GitHub repository username.
+### 2. Clone this workshop
 
-### Clone your fork of the workshop
-
-Clone your copy of the workshop codebase and switch to the `workshop` branch
+Clone your copy of the workshop codebase 
 
 ```zsh
-git clone https://github.com/<INSERT-YOUR-GITHUB-USERNAME>/utxo-workshop.git
-git fetch origin workshop:workshop
-git checkout workshop
+git clone https://github.com/substrate-developer-hub/utxo-workshop.git
+```
 
+## UI Demo
+
+In this UI demo, you will interact with the UTXO blockchain via the [Polkadot UI](https://substrate.dev/docs/en/development/front-end/polkadot-js).
+
+
+1. Compile and build a release in dev mode
+```
 # Initialize your Wasm Build environment:
 ./scripts/init.sh
 
@@ -59,46 +53,36 @@ git checkout workshop
 cargo build --release
 ```
 
-## Demo Polkadot UI
+2. Start your node & start producing blocks:
+```zsh
+./target/release/utxo-workshop --dev
 
-You can use the [Polkadot UI](https://substrate.dev/docs/en/development/front-end/polkadot-js) to exercise the capabilities of your UTXO blockchain to ensure that everything is working as expected. First, you will need ensure that any existing UTXO blockchain data has been removed and then build the UTXO blockchain:
+# If you already modified state, run this to purge the chain
+./target/release/utxo-workshop purge-chain --dev
+```
+
+3. In the console, notice the following helper printouts. In particular, notice a seed account `Alice` was already seeded with `100 UTXO` upon the genesis block. 
+
+Notice we've printed out a few more helper hashes for you, including the transaction encoding for if `Alice were to send Bob 50 UTXO`.
 
 ```zsh
-./target/release/utxo-workshop purge-chain --dev
-./target/release/utxo-workshop --dev
+TODO put printouts here
 ```
 
-You will notice that when you start the UTXO blockchain there is some output that is provided to help you with the following steps:
-```
-Initial UTXO Hash: 0x02f8ef6ff423559b1d07a31075d83c00883fbf02e054af102ab4a0ed8c50d2c5
-Transaction #1 TransactionOutput {
-	value: 100,
-	pubkey: 0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48,
-	salt: 0 },
-	Hash: 0x6cef4a2aa20b106a010cc0cdeebd7f48767372e9b68e37704d595c6abed6b2be
-Transaction #2 TransactionOutput {
-	value: 340282366920938463463374607431768211355,
-	pubkey: 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d,
-	salt: 0 },
-	Hash: 0x4478cdec8efc46049b9b5ef6f615255455c39b67e9a932314dc81a2d63bd9681
-```
+4. Open [Polkadot JS](https://polkadot.js.org/apps/#/settings). Make sure the client is connected to your local node by going to Settings > General, and selecting `Local Node` in the `remote node` dropdown.
 
-1. Visit [Polkadot JS](https://polkadot.js.org/apps/#/settings)
-  - Make sure you are using a browser that is compatible with local development or [consider running the UI locally](https://github.com/polkadot-js/apps)
+5. This UTXO project defines custom datatypes that the JS client cannot infer. Define the custom types in PolkadotJS by going to Settings > Developer tab and paste in the following JSON:
 
-2. Load the UTXO type definitions in Settings > Developer
 ```json
 {
   "Value": "u128",
-  "LockStatus": "u32",
   "TransactionInput": {
-    "parent_output": "Hash",
-    "signature": "Signature"
+    "outpoint": "Hash",
+    "sigscript": "Hash"
   },
   "TransactionOutput": {
     "value": "Value",
-    "pubkey": "Hash",
-    "salt": "u64"
+    "pubkey": "Hash"
   },
   "Transaction": {
     "inputs": "Vec<TransactionInput>",
@@ -107,64 +91,44 @@ Transaction #2 TransactionOutput {
 }
 ```
 
-3. Check that the genesis block contains 1 pre-configured UTXO for Alice as follows:
-```rust
-utxo::TransactionOutput {
-	value: utxo::Value::max_value(),
-	pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
-	salt: 0,
-}
-```
-  - Use the Polkadot JS Chain State app to query the `unspentOutputs` storage map from the `utxoModule`
-  - Query the storage map with the value `0x02f8ef6ff423559b1d07a31075d83c00883fbf02e054af102ab4a0ed8c50d2c5`, which is the hash of the above transaction
-  - You can [use the `subkey` tool to confirm that the public key associated with the initial UTXO belongs to Alice](https://substrate.dev/docs/en/next/development/tools/subkey#well-known-keys)
+6. **Check that Alice already has 100 UTXO at genesis**. In `Chain State` > `Storage`, select `utxoModule`. Input the hash `xxxx`. Click the `+` notation to query blockchain state.
 
-4. Send a new UTXO transaction from Alice as follows: 
-```rust
-utxo::Transaction {
-	inputs: [ utxo::TransactionInput {
-		parent_output: 0x02f8ef6ff423559b1d07a31075d83c00883fbf02e054af102ab4a0ed8c50d2c5,
-		signature: sig_alice(parent_output)
-	}],
-	outputs: [ utxo::TransactionOutput {
-		value: 100,
-		pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Bob").as_slice()),
-		salt: 0,
-	}, utxo::TransactionOutput {
-		value: utxo::Value::max_value() - 100,
-		pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
-		salt: 0,
-	}]
-}
-```
-  - Use the Polkadot JS Extrinsics app to invoke the `execute` function from the `utxoModule`
-  - You will notice that the transaction's input is the pre-configured UTXO from the genesis block
-  - Use the Polkadot JS Toolbox app to generate the input's `signature` (make sure you are using Alice's account to generate this value)
-  - The public keys are provided for you via console output, which you can easily verify using the `subkey` tool
+Verify that: 
+ - UTXO value is `100`
+ - The pubkey indeed belongs to Alice (which is a default, hardcoded account). You use the [subkey](https://substrate.dev/docs/en/next/development/tools/subkey#well-known-keys) tool to confirm that the pubkey indeed belongs to Alice
 
-5. Use the Chain State app to verify the following:
-  - The pre-configured UTXO from the genesis block (`0x02f8ef6ff423559b1d07a31075d83c00883fbf02e054af102ab4a0ed8c50d2c5`) no longer appears in the `unspentOutput` map
-  - The `unspentOutput` map has references to both of the outputs from the above transaction (the transaction hashes are provided for you via console output)
+7. **Spend Alice's UTXO, giving 50 to Bob.** In the `Extrinsics` tab, invoke the `spend` function from the `utxoModule`, using Alice as the transaction sender. Submit the following transaction hash `TODO` in which Alice sends Bob 50 utxo, burning the remaining amout. 
 
-## Challenge 1: UTXO Transaction Security
-UTXO validates transactions as follows: 
-- Check signatures
-- Check all inputs are unspent 
-- Check input == output value
-- Set Input to "spent"
+8. **Verify that your transaction succeeded**. In `Chain State`, look up the following UTXO hash: `TODO`.
+Also verify that the genesis utxo has been spent and no longer exists. 
 
-Similarly in our UTXO implementation, we need to prevent malicious users from sending bad transactions. `utxo.rs` contains some tests that simulate these malicious attacks. 
+Coming soon: A video walkthrough of the above. 
 
-Your challenge is to extend the implementation such that only secure transactions will go through.
+## Beginner Workshop
+**Estimated time**: 2 hours
 
-*Hint: Remember the check-before-state-change pattern!*
+In this workshop, you will: 
+- Get familiar with basic Rust and Substrate functionality
+- Prevent malicious users from sending bad UTXO transactions
+
+Your challenge is to fix the code such that: 
+1. The Rust compiler compiles without errors
+2. All tests in `utxo.rs` pass, ensuring secure transactions
 
 ### Directions
-*Make sure you have created a local copy of the remote `workshop` branch*
+1. Checkout the `workshop` branch. The `Master` branch has the solutions, so don't peek!
 
-1. Run cargo test: `cargo test -p utxo-runtime`
+```zsh
+git fetch origin workshop:workshop
+git checkout workshop
+```
 
-2. Notice that 7/8 tests are failing!
+2. Cd into the base directory. Try running the test with: `cargo test -p utxo-runtime`. Notice all the compiler errors!
+```zsh
+ADD all the errors
+```
+
+3. Once your code compiles, that `X/9` tests are failing!
 ```zsh
 failures:
     utxo::tests::attack_by_double_counting_input
@@ -176,7 +140,7 @@ failures:
     utxo::tests::attack_with_invalid_signature
 ```
 
-3. In `utxo.rs`, extend `check_transaction()` to make the following tests pass. 
+4. Go to `utxo.rs` and read the workshop comments. Your goal is to edit the `check_transaction()` function & make all tests pass.
 
 *Hint: You may want to make them pass in the following order!*
 
@@ -190,37 +154,19 @@ failures:
 [6] test utxo::tests::attack_by_over_spending ... ok
 ```
 
-## Challenge 2: Transaction Ordering
+## Advanced Workshop
+**VIDEO TUTORIALS COMING SOON**
 
-**Scenario**: Imagine a situation where Alice pays Bob via **transaction A**, then Bob uses his new utxo to pay Charlie, via **transaction B**. In short, B depends on the success of A. 
+**Estimated time**: 1 hour
 
-However, depending on network latency, the runtime might deliver **transaction B** to a node's transaction pool before delivering **transaction A**!
+In this workshop, you will implement this UTXO project from scratch and learn:
+- How to implement the UTXO model on Substrate
+- How to secure UTXO transactions against attacks
+- How to seed genesis block with UTXOs
+- How to reward block validators in this environment
+- How to customize transaction pool logic on Substrate
+- Good coding patterns for working with Substrate & Rust
 
-Your challenge is to overcome this race condition.
-
-A naive solution is to simply drop transaction B. But Substrate lets you implement transaction ordering logic. 
-
-In Substrate, you can specify the requirements for dispatching a transaction, e.g. wait for transaction A to arrive before dispatching B.
-
-Directions: 
-1. Read about a [transaction lifecycle](https://substrate.dev/docs/en/1.0/overview/transaction-lifecycle) in Substrate
-
-2. Read about [TaggedTransactionQueue](https://crates.parity.io/sp_transaction_pool/runtime_api/trait.TaggedTransactionQueue.html) and [TransactionValidity](https://crates.parity.io/sp_runtime/transaction_validity/type.TransactionValidity.html)
-
-3. Implement the correct transaction ordering logic such that transactions with pending dependencies can wait in the transaction pool until its requirements are satisfied.
-
-Hint: You can filter for specific types of transactions using the following syntax: 
-
-```rust
-if let Some(&utxo::Call::execute(ref transaction)) = IsSubType::<utxo::Module<Runtime>, Runtime>::is_sub_type(&tx.function) {
-    // Your implementation here
-}
-```
-
-## Challenge 3: Extensions
-You can try building the following extensions:
-- Give transactions in the pool a smarter longevity lifetime
-- Implement coinbase transactions, by letting users add value through work
 
 ## Helpful Resources
 - [Substrate documentation](http://crates.parity.io)

--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ Verify that:
 - pubkey: `0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48`
 ```
 
-8. **Verify that your transaction succeeded**. In `Chain State`, look up the UTXO hash: `0xdbc75ab8ee9b83dcbcea4695f9c42754d94e92c3c397d63b1bc627c2a2ef94e6` to verify that a new UTXO of 50, belonging to Bob, now exists! Also you can verify that the genesis utxo has been spent and no longer exists in UtxoStore. 
+Send this as an unsigned transaction, since the proof is already in the `sigscript` input.
 
-Coming soon: A video walkthrough of the above demo.
+8. **Verify that your transaction succeeded**. In `Chain State`, look up the UTXO hash: `0xdbc75ab8ee9b83dcbcea4695f9c42754d94e92c3c397d63b1bc627c2a2ef94e6` to verify that a new UTXO of 50, belonging to Bob, now exists! Also you can verify that Alice's original UTXO has been spent and no longer exists in UtxoStore.
+
+*Coming soon: A video walkthrough of the above demo.*
 
 ## Beginner Workshop
 **Estimated time**: 2 hours

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UTXO on Substrate
 
-A UTXO chain implementation on Substrate, with two self guided workshops.Original [UXTO inspiration](https://github.com/0x7CFE/substrate-node-template/tree/utxo) by [Dmitriy Kashitsyn](https://github.com/0x7CFE).
+A UTXO chain implementation on Substrate, with two self-guided workshops.Original [UXTO inspiration](https://github.com/0x7CFE/substrate-node-template/tree/utxo) by [Dmitriy Kashitsyn](https://github.com/0x7CFE).
 
 Substrate Version: `pre-v2.0`. For educational purposes only. 
 
@@ -43,8 +43,9 @@ git clone https://github.com/substrate-developer-hub/utxo-workshop.git
 
 In this UI demo, you will interact with the UTXO blockchain via the [Polkadot UI](https://substrate.dev/docs/en/development/front-end/polkadot-js). 
 
-The following demo takes you through a scenario where `Alice sends Bob a UTXO with value 50` from her original UTXO (value 100) that she already had during genesis: 
-
+The following demo takes you through a scenario where: 
+- Alice already owns a UTXO of value 100 upon genesis
+- Alice sends Bob a UTXO with value 50, tipping the remainder to validators
 
 1. Compile and build a release in dev mode
 ```
@@ -63,11 +64,7 @@ cargo build --release
 ./target/release/utxo-workshop purge-chain --dev
 ```
 
-3. In the console, notice the following helper printouts. In particular, notice the default account `Alice` was already has `100 UTXO` upon the genesis block.
-
-```zsh
-
-```
+3. In the console, notice the helper printouts. In particular, notice the default account `Alice` was already has `100 UTXO` upon the genesis block.
 
 4. Open [Polkadot JS](https://polkadot.js.org/apps/#/settings), making sure the client is connected to your local node by going to Settings > General, and selecting `Local Node` in the `remote node` dropdown.
 
@@ -93,21 +90,20 @@ cargo build --release
 
 6. **Check that Alice already has 100 UTXO at genesis**. In `Chain State` > `Storage`, select `utxoModule`. Input the hash `0x76584168d10a20084082ed80ec71e2a783abbb8dd6eb9d4893b089228498e9ff`. Click the `+` notation to query blockchain state.
 
-Verify that: 
- - This UTXO has a value of `100`
- - This UTXO belongs to Alice's pubkey. You use the [subkey](https://substrate.dev/docs/en/next/development/tools/subkey#well-known-keys) tool to confirm that the pubkey indeed belongs to Alice
+    Notice that: 
+    - This UTXO has a value of `100`
+    - This UTXO belongs to Alice's pubkey. You use the [subkey](https://substrate.dev/docs/en/next/development/tools/subkey#well-known-keys) tool to confirm that the pubkey indeed belongs to Alice
 
 7. **Spend Alice's UTXO, giving 50 to Bob.** In the `Extrinsics` tab, invoke the `spend` function from the `utxoModule`, using Alice as the transaction sender. Use the following input parameters:
 
-- outpoint: `0x76584168d10a20084082ed80ec71e2a783abbb8dd6eb9d4893b089228498e9ff`
-- sigscript: `0x6ceab99702c60b111c12c2867679c5555c00dcd4d6ab40efa01e3a65083bfb6c6f5c1ed3356d7141ec61894153b8ba7fb413bf1e990ed99ff6dee5da1b24fd83`
-- value: `50`
-- pubkey: `0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48`
-```
+    - outpoint: `0x76584168d10a20084082ed80ec71e2a783abbb8dd6eb9d4893b089228498e9ff`
+    - sigscript: `0x6ceab99702c60b111c12c2867679c5555c00dcd4d6ab40efa01e3a65083bfb6c6f5c1ed3356d7141ec61894153b8ba7fb413bf1e990ed99ff6dee5da1b24fd83`
+    - value: `50`
+    - pubkey: `0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48`
 
-Send this as an unsigned transaction, since the proof is already in the `sigscript` input.
+    Send this as an `unsigned` transaction. With UTXO blockchains, the proof is already in the `sigscript` input.
 
-8. **Verify that your transaction succeeded**. In `Chain State`, look up the UTXO hash: `0xdbc75ab8ee9b83dcbcea4695f9c42754d94e92c3c397d63b1bc627c2a2ef94e6` to verify that a new UTXO of 50, belonging to Bob, now exists! Also you can verify that Alice's original UTXO has been spent and no longer exists in UtxoStore.
+8. **Verify that your transaction succeeded**. In `Chain State`, look up the newly created UTXO hash: `0xdbc75ab8ee9b83dcbcea4695f9c42754d94e92c3c397d63b1bc627c2a2ef94e6` to verify that a new UTXO of 50, belonging to Bob, now exists! Also you can verify that Alice's original UTXO has been spent and no longer exists in UtxoStore.
 
 *Coming soon: A video walkthrough of the above demo.*
 
@@ -130,35 +126,47 @@ git fetch origin workshop:workshop
 git checkout workshop
 ```
 
-2. Cd into the base directory. Try running the test with: `cargo test -p utxo-runtime`. Notice all the compiler errors!
+2. Cd into the base directory. Try running the test with: `cargo test -p utxo-runtime`.
+
 ```zsh
-ADD all the errors
+compiling utxo-runtime v2.0.0 (/Users/nicole/Desktop/utxo-workshop/runtime)
+error[E0433]: failed to resolve: use of undeclared type or module `H512`
+   --> /Users/nicole/Desktop/utxo-workshop/runtime/src/utxo.rs:236:31
+    |
+236 |             input.sigscript = H512::zero();
+    |                               ^^^^ use of undeclared type or module `H512`
+
+...
 ```
 
-3. Once your code compiles, that `X/9` tests are failing!
+3. Your first task: fix all the compiler errors! Hint: Look for the `TODO` comments in `utxo.rs` to see where to fix errors. 
+
+4. Once your code compiles, it's now time to fix the `8` failing tests!
+
 ```zsh
 failures:
     utxo::tests::attack_by_double_counting_input
     utxo::tests::attack_by_double_generating_output
     utxo::tests::attack_by_over_spending
-    utxo::tests::attack_by_overflowing
+    utxo::tests::attack_by_overflowing_value
     utxo::tests::attack_by_permanently_sinking_outputs
     utxo::tests::attack_with_empty_transactions
     utxo::tests::attack_with_invalid_signature
+    utxo::tests::test_simple_transaction
 ```
 
-4. Go to `utxo.rs` and read the workshop comments. Your goal is to edit the `check_transaction()` function & make all tests pass.
-
-*Hint: You may want to make them pass in the following order!*
+5. In `utxo.rs`, edit the logic in `check_transaction()` function to make all tests pass.
 
 ```zsh
-[0] test utxo::tests::attack_with_empty_transactions ... ok
-[1] test utxo::tests::attack_by_double_counting_input ... ok
-[2] test utxo::tests::attack_by_double_generating_output ... ok
-[3] test utxo::tests::attack_with_invalid_signature ... ok
-[4] test utxo::tests::attack_by_permanently_sinking_outputs ... ok
-[5] test utxo::tests::attack_by_overflowing ... ok
-[6] test utxo::tests::attack_by_over_spending ... ok
+running 9 tests
+test utxo::tests::attack_by_overflowing_value ... ok
+test utxo::tests::attack_by_double_counting_input ... ok
+test utxo::tests::attack_by_double_generating_output ... ok
+test utxo::tests::attack_by_over_spending ... ok
+test utxo::tests::attack_with_empty_transactions ... ok
+test utxo::tests::attack_with_invalid_signature ... ok
+test utxo::tests::attack_by_permanently_sinking_outputs ... ok
+test utxo::tests::test_simple_transaction ... ok
 ```
 
 ## Advanced Workshop
@@ -166,7 +174,9 @@ failures:
 
 **Estimated time**: 1 hour
 
-In this workshop, you will implement this UTXO project from scratch and learn:
+In this workshop, you will implement this UTXO project from scratch using Substrate.
+
+You will learn:
 - How to implement the UTXO model on Substrate
 - How to secure UTXO transactions against attacks
 - How to seed genesis block with UTXOs

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,6 +4,9 @@ edition = '2018'
 name = 'utxo-runtime'
 version = '2.0.0'
 
+[dependencies]
+hex-literal = "0.2.1"
+
 [build-dependencies.wasm-builder-runner]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-wasm-builder-runner'

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -349,7 +349,7 @@ impl_runtime_apis! {
                 match <utxo::Module<Runtime>>::has_race_condition(&transaction) {
 
                     // All input UTXOs were found, so we consider input conditions to be met
-                    None => { requires = Vec::new(); } // TODO: is this line necessary?
+                    None => { requires = Vec::new(); }
                     
                     // Since some referred UTXOs were not found in the storage yet,
                     // we tag current transaction as requiring those particular UTXOs
@@ -371,7 +371,7 @@ impl_runtime_apis! {
                     requires,
                     provides,
                     priority: TransactionPriority::max_value(),
-                    longevity: TransactionLongevity::max_value(), // "Forever" This value can be changed so that missinginputs trx can eventually be rejected.
+                    longevity: TransactionLongevity::max_value(),
                     propagate: true,
                 });
             }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,7 +14,7 @@ use sp_runtime::{
     ApplyExtrinsicResult, generic, create_runtime_str, impl_opaque_keys, MultiSignature
 };
 use sp_runtime::transaction_validity::{
-    InvalidTransaction, TransactionPriority, TransactionLongevity, TransactionValidity, TransactionValidityError, ValidTransaction
+    TransactionPriority, TransactionLongevity, TransactionValidity, ValidTransaction
 };
 use sp_runtime::traits::{
     NumberFor, BlakeTwo256, Block as BlockT, StaticLookup, Verify, ConvertInto, IdentifyAccount

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -335,6 +335,8 @@ impl_runtime_apis! {
         }
     }
 
+    // Documentation is here: 
+    // https://substrate.dev/rustdocs/master/sp_transaction_pool/runtime_api/trait.TaggedTransactionQueue.html#method.validate_transaction
     impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
         fn validate_transaction(tx: <Block as BlockT>::Extrinsic) -> TransactionValidity {
             use sp_runtime::traits::Hash;
@@ -389,12 +391,13 @@ impl_runtime_apis! {
                     requires,
                     provides,
                     priority,
-                    longevity: TransactionLongevity::max_value(),
+                    longevity: TransactionLongevity::max_value(), // "Forever" This value can be changed so that missinginputs trx can eventually be rejected.
                     propagate: true,
                 });
             }
 
             // Fall back to default logic for non UTXO::execute extrinsics
+            // TODO find out when validate_transaction is run
             Executive::validate_transaction(tx)
         }
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -342,7 +342,7 @@ impl_runtime_apis! {
             use sp_runtime::traits::Hash;
             
             // Extrinsics representing UTXO transaction need some special handling
-            if let Some(&utxo::Call::execute(ref transaction)) = IsSubType::<utxo::Module<Runtime>, Runtime>::is_sub_type(&tx.function) {
+            if let Some(&utxo::Call::spend(ref transaction)) = IsSubType::<utxo::Module<Runtime>, Runtime>::is_sub_type(&tx.function) {
                 // List of tags to require
                 let requires;
                 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -377,7 +377,6 @@ impl_runtime_apis! {
             }
 
             // Fall back to default logic for non UTXO::execute extrinsics
-            // TODO find out when validate_transaction is run
             Executive::validate_transaction(tx)
         }
     }

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -223,7 +223,7 @@ impl<T: Trait> Module<T> {
         }
     }
         
-    // Strips a transaction of its Signature fields by replacing value with ZERO-initialized fixed hash.
+    /// Strips a transaction of its signatures by replacing the sigscript field of each input with ZERO-initialized fixed hash.
     pub fn get_simple_transaction(_transaction: &Transaction) -> Vec<u8> {//&'a [u8] {
         let mut trx = _transaction.clone();
         for input in trx.inputs.iter_mut() {

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -174,16 +174,6 @@ pub type CheckResult<'a> = Result<CheckInfo<'a>, &'static str>;
 
 impl<T: Trait> Module<T> {
     /// Check transaction for validity.
-    /// 
-    /// Ensures that:
-    /// - inputs and outputs are not empty
-    /// - all inputs match to existing, unspent and unlocked outputs
-    /// - each input is used exactly once
-    /// - each output is defined exactly once and has nonzero value
-    /// - total output value must not exceed total input value
-    /// - new outputs do not collide with existing ones
-    /// - sum of input and output values does not overflow
-    /// - provided signatures are valid
     pub fn check_transaction(_transaction: &Transaction) -> CheckResult<'_> {
         ensure!(!_transaction.inputs.is_empty(), "no inputs"); // returns Err(...) if incorrect
         ensure!(!_transaction.outputs.is_empty(), "no outputs");
@@ -320,29 +310,6 @@ impl<T: Trait> Module<T> {
 
         Ok(())
     }
-
-    // pub fn lock_utxo(hash: &H256, until: Option<T::BlockNumber>) -> DispatchResult {
-    //     ensure!(!<LockedOutputs<T>>::exists(hash), "utxo is already locked");
-    //     ensure!(<UnspentOutputs>::exists(hash), "utxo does not exist");
-
-    //     if let Some(until) = until {
-    //         ensure!(
-    //             until > <system::Module<T>>::block_number(),
-    //             "block number is in the past"
-    //         );
-    //         <LockedOutputs<T>>::insert(hash, LockStatus::LockedUntil(until));
-    //     } else {
-    //         <LockedOutputs<T>>::insert(hash, LockStatus::Locked);
-    //     }
-
-    //     Ok(())
-    // }
-
-    // pub fn unlock_utxo(hash: &H256) -> DispatchResult {
-    //     ensure!(!<LockedOutputs<T>>::exists(hash), "utxo is not locked");
-    //     <LockedOutputs<T>>::remove(hash);
-    //     Ok(())
-    // }
 }
 
 /// Tests for this module
@@ -395,40 +362,6 @@ mod tests {
 
     type Utxo = Module<Test>;
 
-    // // Test set up
-    // // Alice's Public Key: Pair::from_seed(*b"12345678901234567890123456789012");
-    // const ALICE_KEY: [u8; 32] = [68, 169, 150, 190, 177, 238, 247, 189, 202, 185, 118, 171, 109, 44, 162, 97, 4, 131, 65, 100, 236, 242, 143, 179, 117, 96, 5, 118, 252, 198, 235, 15];
-
-    // // Alice's Signature to spend alice_utxo(): signs a token she owns Pair::sign(&message[..])
-    // const ALICE_SIG: [u8; 64] = [220, 109, 218, 80, 85, 118, 140, 48, 193, 19, 77, 200, 60, 229, 91, 60, 70, 54, 54, 137, 154, 51, 201, 252, 98, 219, 172, 57, 1, 139, 86, 47, 162, 21, 50, 179, 196, 135, 167, 29, 171, 85, 3, 111, 46, 110, 10, 25, 239, 152, 176, 82, 114, 192, 125, 182, 240, 19, 192, 85, 227, 101, 148, 0]; //[148, 250, 180, 5, 112, 29, 240, 241, 122, 26, 249, 125, 87, 102, 180, 179, 127, 79, 120, 72, 253, 21, 26, 215, 157, 35, 208, 126, 54, 181, 150, 12, 117, 177, 134, 104, 124, 16, 70, 249, 31, 4, 131, 192, 247, 143, 73, 123, 24, 66, 144, 189, 64, 90, 65, 79, 185, 36, 107, 135, 195, 212, 219, 10];
-
-    // // Alice's Signature to spend alice_utxo_100(): signs a token she owns Pair::sign(&message[..])
-    // const ALICE_SIG100: [u8; 64] = [212, 108, 199, 137, 228, 149, 233, 230, 129, 251, 80, 16, 160, 95, 191, 199, 207, 176, 151, 234, 5, 157, 245, 136, 62, 169, 87, 203, 188, 11, 47, 76, 230, 159, 10, 125, 35, 244, 76, 89, 174, 52, 41, 78, 32, 102, 200, 231, 31, 22, 35, 42, 143, 85, 255, 235, 31, 58, 236, 95, 52, 205, 224, 2]; // [228, 33, 239, 151, 136, 93, 241, 82, 205, 248, 154, 139, 52, 157, 231, 222, 66, 242, 86, 120, 92, 170, 98, 214, 78, 226, 93, 229, 130, 174, 168, 26, 7, 151, 88, 13, 185, 161, 15, 247, 222, 85, 235, 107, 246, 135, 23, 47, 162, 71, 81, 29, 227, 230, 210, 112, 0, 157, 86, 218, 130, 11, 8, 0];
-
-    // // Creates a max value UTXO for Alice
-    // fn alice_utxo() -> (H256, TransactionOutput) {
-
-    //     let transaction = TransactionOutput {
-    //         value: Value::max_value(),
-    //         pubkey: H256::from_slice(&ALICE_KEY),
-    //         salt: 0,
-    //     };
-
-    //     (BlakeTwo256::hash_of(&transaction), transaction)
-    // }
-
-    // // Creates a 100 value UTXO for Alice
-    // // TODO: delte this fn
-    // fn alice_utxo_100() -> (H256, TransactionOutput) {
-    //     let transaction = TransactionOutput {
-    //         value: 100,
-    //         pubkey: H256::from_slice(&ALICE_KEY),
-    //         salt: 0,
-    //     };
-
-    //     (BlakeTwo256::hash_of(&transaction), transaction)
-    // }
-
     // Creates a UTXO for a designated pubkey out of thin air
     // Inputs: value, recipient
     // Outputs: Tuple of 
@@ -439,27 +372,24 @@ mod tests {
             pubkey: H256::from(pubkey), //H256::from_slice(&ALICE_KEY),
             salt: 0,
         };
-        print!("NEW UTXO CREATED HASH: {:?}", BlakeTwo256::hash_of(&transaction));
+        
         (BlakeTwo256::hash_of(&transaction), transaction)
     }
 
     // need to manually import this crate since its no include by default
     use hex_literal::hex;
-    
+
     const ALICE_PHRASE: &str = "news slush supreme milk chapter athlete soap sausage put clutch what kitten";
     const BOB_PHRASE: &str = "lobster flock few equip connect boost excuse glass machine find wonder tattoo";
-    // const BOB_PUB_KEY: [u8; 32] = hex!("fe7fce341ff73e1db537daa4cc8c539997a8b0654b06cb81c47e4f067f55a65a");
     const GENESIS_UTXO: [u8; 32] = hex!("0a746d36b8357640690608da229648a51552b0add7ddbd8803efa1013cadbd4c");
     
-    // TEST SETUP:
     // This function basically just builds a genesis storage key/value store according to our desired mockup.
     // We start each test by giving Alice 100 utxo to start with.
-    // Hint: seed utxo hash: 0x0a746d36b8357640690608da229648a51552b0add7ddbd8803efa1013cadbd4cALL
     fn new_test_ext() -> sp_io::TestExternalities {
     
         let keystore = KeyStore::new(); // a key storage to store new key pairs during testing
         let alice_pub_key = keystore.write().sr25519_generate_new(SR25519, Some(ALICE_PHRASE)).unwrap();
-        let bob_pub_key = keystore.write().sr25519_generate_new(SR25519, Some(BOB_PHRASE)).unwrap();
+        let _bob_pub_key = keystore.write().sr25519_generate_new(SR25519, Some(BOB_PHRASE)).unwrap();
 
         let mut t = system::GenesisConfig::default()
             .build_storage::<Test>()
@@ -475,20 +405,18 @@ mod tests {
             .top,
         );
         
+        // Print the values to get GENESIS_UTXO
+        
         let mut ext = sp_io::TestExternalities::from(t);
         ext.register_extension(KeystoreExt(keystore));
         ext
     }
 
-
     #[test]
-    fn valid_transaction() {
+    fn test_simple_transaction() {
         new_test_ext().execute_with(|| {
-            
             let alice_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[0];
             let bob_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[1];
-
-            // 1. Alice signs over a new transaction, splitting her utxo
             let alice_signature = sp_io::crypto::sr25519_sign(SR25519, &alice_pub_key, &GENESIS_UTXO).unwrap();
 
             let transaction = Transaction {
@@ -503,17 +431,13 @@ mod tests {
                 }],
             };
             
-            // Check transaction went through ok
             let transaction_hash = BlakeTwo256::hash_of(&transaction.outputs[0]);
+
             assert_ok!(Utxo::execute(Origin::signed(0), transaction)); // technical we're signing with an account, that's not the corresponding key
-            
-            // Check that alice's utxo is gone.
-            // Bob has new utxo of value 50.
             assert!(!UnspentOutputs::exists(H256::from(GENESIS_UTXO)));
             assert!(UnspentOutputs::exists(transaction_hash));
         });
     }
-
 
     // Exercise 1: Fortify transactions against attacks
     // ================================================
@@ -524,229 +448,205 @@ mod tests {
     // Hint: Examine types CheckResult, CheckInfo for the expected behaviors of this function
     // Hint: Make this function public, as it will be later used outside of this module
 
-    // #[test]
-    // fn attack_with_empty_transactions() {
-    //     new_test_ext().execute_with(|| {
-    //         assert!(
-    //             Utxo::execute(Origin::signed(0), Transaction::default()).is_err(), // an empty trx
-    //             "no inputs"
-    //         );
+    #[test]
+    fn attack_with_empty_transactions() {
+        new_test_ext().execute_with(|| {
+            assert!(
+                Utxo::execute(Origin::signed(0), Transaction::default()).is_err(), // an empty trx
+                "no inputs"
+            );
 
-    //         assert!(
-    //             Utxo::execute(
-    //                 Origin::signed(0),
-    //                 Transaction {
-    //                     inputs: vec![TransactionInput::default()], // an empty trx
-    //                     outputs: vec![],
-    //                 }
-    //             )
-    //             .is_err(),
-    //             "no outputs"
-    //         );
-    //     });
-    // }
+            assert!(
+                Utxo::execute(
+                    Origin::signed(0),
+                    Transaction {
+                        inputs: vec![TransactionInput::default()], // an empty trx
+                        outputs: vec![],
+                    }
+                )
+                .is_err(),
+                "no outputs"
+            );
+        });
+    }
 
-    // #[test]
-    // fn attack_by_double_counting_input() {
-    //     new_test_ext().execute_with(|| {
-    //         let (parent_hash, _) = alice_utxo();
+    #[test]
+    fn attack_by_double_counting_input() {
+        new_test_ext().execute_with(|| {
+            let alice_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[0];
+            let alice_signature = sp_io::crypto::sr25519_sign(SR25519, &alice_pub_key, &GENESIS_UTXO).unwrap();
 
-    //         // println!("PARENT HASH: {:x?}: ", parent_hash);
-    //         let transaction = Transaction {
-    //             inputs: vec![
-    //                 TransactionInput {
-    //                     parent_output: parent_hash,
-    //                     signature: Signature::from_slice(&ALICE_SIG),
-    //                 },
-    //                 TransactionInput {
-    //                     parent_output: parent_hash, // Double spending input!
-    //                     signature: Signature::from_slice(&ALICE_SIG),
-    //                 },
-    //             ],
-    //             outputs: vec![TransactionOutput {
-    //                 value: 100,
-    //                 pubkey: H256::from_slice(&ALICE_KEY),
-    //                 salt: 0,
-    //             }],
-    //         };
+            let transaction = Transaction {
+                inputs: vec![
+                    TransactionInput {
+                        parent_output: H256::from(GENESIS_UTXO.clone()),
+                        signature: H512::from(alice_signature.clone()),
+                    },
+                    // A double spend of the same UTXO!
+                    TransactionInput {
+                        parent_output: H256::from(GENESIS_UTXO),
+                        signature: H512::from(alice_signature),
+                    },
+                ],
+                outputs: vec![TransactionOutput {
+                    value: 100,
+                    pubkey: H256::from(alice_pub_key),
+                    salt: 0,
+                }],
+            };
 
-    //         assert!(
-    //             Utxo::execute(Origin::signed(0), transaction).is_err(),
-    //             "each input must only be used once"
-    //         );
-    //     });
-    // }
+            assert!(
+                Utxo::execute(Origin::signed(0), transaction).is_err(),
+                "each input must only be used once"
+            );
+        });
+    }
 
-    // #[test]
-    // fn attack_by_double_generating_output() {
-    //     new_test_ext().execute_with(|| {
-    //         let (parent_hash, _) = alice_utxo();
+    #[test]
+    fn attack_by_double_generating_output() {
+        new_test_ext().execute_with(|| {
 
-    //         let transaction = Transaction {
-    //             inputs: vec![TransactionInput {
-    //                 parent_output: parent_hash,
-    //                 signature: Signature::from_slice(&ALICE_SIG),
-    //             }],
-    //             outputs: vec![
-    //                 TransactionOutput {
-    //                     value: 100,
-    //                     pubkey: H256::from_slice(&ALICE_KEY),
-    //                     salt: 0,
-    //                 },
-    //                 TransactionOutput {
-    //                     // Same output defined here!
-    //                     value: 100,
-    //                     pubkey: H256::from_slice(&ALICE_KEY),
-    //                     salt: 0,
-    //                 },
-    //             ],
-    //         };
-
-    //         assert!(
-    //             Utxo::execute(Origin::signed(0), transaction).is_err(),
-    //             "each output must be defined only once"
-    //         );
-    //     });
-    // }
-
-    // #[test]
-    // fn attack_with_invalid_signature() {
-    //     new_test_ext().execute_with(|| {
-    //         let (parent_hash, _) = alice_utxo();
-
-    //         let transaction = Transaction {
-    //             inputs: vec![TransactionInput {
-    //                 parent_output: parent_hash,
-    //                 signature: H512::random(), // Just a random signature!
-    //             }],
-    //             outputs: vec![TransactionOutput {
-    //                 value: 100,
-    //                 pubkey: H256::from_slice(&ALICE_KEY),
-    //                 salt: 0,
-    //             }],
-    //         };
-
-    //         assert!(
-    //             Utxo::execute(Origin::signed(0), transaction).is_err(),
-    //             "signature must be valid"
-    //         );
-    //     });
-    // }
-
-    // #[test]
-    // fn attack_by_permanently_sinking_outputs() {
-    //     new_test_ext().execute_with(|| {
-    //         let (parent_hash, _) = alice_utxo();
-
-    //         let transaction = Transaction {
-    //             inputs: vec![TransactionInput {
-    //                 parent_output: parent_hash,
-    //                 signature: Signature::from_slice(&ALICE_SIG),
-    //             }],
-    //             outputs: vec![TransactionOutput {
-    //                 value: 0, // A 0 value output burns this output forever!
-    //                 pubkey: H256::from_slice(&ALICE_KEY),
-    //                 salt: 0,
-    //             }],
-    //         };
-
-    //         assert!(
-    //             Utxo::execute(Origin::signed(0), transaction).is_err(),
-    //             "output value must be nonzero"
-    //         );
-    //     });
-    // }
-
-    // #[test]
-    // fn attack_by_overflowing() {
-    //     new_test_ext().execute_with(|| {
-    //         let (parent_hash, _) = alice_utxo();
-
-    //         let transaction = Transaction {
-    //             inputs: vec![TransactionInput {
-    //                 parent_output: parent_hash,
-    //                 signature: Signature::from_slice(&ALICE_SIG),
-    //             }],
-    //             outputs: vec![
-    //                 TransactionOutput {
-    //                     value: Value::max_value(),
-    //                     pubkey: H256::from_slice(&ALICE_KEY),
-    //                     salt: 1,
-    //                 },
-    //                 TransactionOutput {
-    //                     value: 10 as Value, // Attempts to do overflow total output value
-    //                     pubkey: H256::from_slice(&ALICE_KEY),
-    //                     salt: 1,
-    //                 },
-    //             ],
-    //         };
-
-    //         assert!(
-    //             Utxo::execute(Origin::signed(0), transaction).is_err(),
-    //             "output value overflow"
-    //         );
-    //     });
-    // }
-
-    // #[test]
-    // fn attack_by_over_spending() {
-    //     new_test_ext().execute_with(|| {
-    //         let (parent_hash, _) = alice_utxo_100();
-
-    //         let transaction = Transaction {
-    //             inputs: vec![TransactionInput {
-    //                 parent_output: parent_hash,
-    //                 signature: Signature::from_slice(&ALICE_SIG100),
-    //             }],
-    //             outputs: vec![
-    //                 TransactionOutput {
-    //                     value: 100 as Value,
-    //                     pubkey: H256::from_slice(&ALICE_KEY),
-    //                     salt: 1,
-    //                 },
-    //                 TransactionOutput {
-    //                     value: 1 as Value, // Creates 1 new utxo out of thin air!
-    //                     pubkey: H256::from_slice(&ALICE_KEY),
-    //                     salt: 1,
-    //                 },
-    //             ],
-    //         };
-
-    //         assert!(
-    //             Utxo::execute(Origin::signed(0), transaction).is_err(),
-    //             "output value must not exceed input value"
-    //         );
-    //     });
-    // }
-    
-    // #[test]
-    // fn valid_transaction() {
-    //     new_test_ext().execute_with(|| {
-
-    //         let keystore = KeyStore::new(); // a key storage to store new key pairs during testing
-    //         let alice_pub_key = keystore.write().sr25519_generate_new(SR25519, None).unwrap();
-
-    //         print!("ALICE Public KEY {:?}", alice_pub_key);
- 
-    //         let (parent_hash, _) = alice_utxo();
-
-    //         let transaction = Transaction {
-    //             inputs: vec![TransactionInput {
-    //                 parent_output: parent_hash,
-    //                 signature: Signature::from_slice(&ALICE_SIG),
-    //             }],
-    //             outputs: vec![TransactionOutput {
-    //                 value: 100,
-    //                 pubkey: H256::from_slice(&ALICE_KEY),
-    //                 salt: 2,
-    //             }],
-    //         };
+            let alice_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[0];
+            let alice_signature = sp_io::crypto::sr25519_sign(SR25519, &alice_pub_key, &GENESIS_UTXO).unwrap();
             
-    //         let output_hash = BlakeTwo256::hash_of(&transaction.outputs[0]);
+            let transaction = Transaction {
+                inputs: vec![TransactionInput {
+                    parent_output: H256::from(GENESIS_UTXO),
+                    signature: H512::from(alice_signature),
+                }],
+                outputs: vec![
+                    TransactionOutput {
+                        value: 100,
+                        pubkey: H256::from(alice_pub_key),
+                        salt: 0,
+                    },
+                    TransactionOutput {
+                        // Same output defined here!
+                        value: 100,
+                        pubkey: H256::from(alice_pub_key),
+                        salt: 0, // TODO check this
+                    },
+                ],
+            };
 
-    //         assert_ok!(Utxo::execute(Origin::signed(0), transaction));
-    //         assert!(!UnspentOutputs::exists(parent_hash));
-    //         assert!(UnspentOutputs::exists(output_hash));
-    //     });
-    // }
+            assert!(
+                Utxo::execute(Origin::signed(0), transaction).is_err(),
+                "each output must be defined only once"
+            );
+        });
+    }
+
+    #[test]
+    fn attack_with_invalid_signature() {
+        new_test_ext().execute_with(|| {
+            let alice_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[0];
+
+            let transaction = Transaction {
+                inputs: vec![TransactionInput {
+                    parent_output: H256::from(GENESIS_UTXO),
+                    // Just a random signature!
+                    signature: H512::random(),
+                }],
+                outputs: vec![TransactionOutput {
+                    value: 100,
+                    pubkey: H256::from(alice_pub_key),
+                    salt: 0,
+                }],
+            };
+
+            assert!(
+                Utxo::execute(Origin::signed(0), transaction).is_err(),
+                "signature must be valid"
+            );
+        });
+    }
+
+    #[test]
+    fn attack_by_permanently_sinking_outputs() {
+        new_test_ext().execute_with(|| {
+            let alice_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[0];
+            let alice_signature = sp_io::crypto::sr25519_sign(SR25519, &alice_pub_key, &GENESIS_UTXO).unwrap();
+
+            let transaction = Transaction {
+                inputs: vec![TransactionInput {
+                    parent_output: H256::from(GENESIS_UTXO),
+                    signature: H512::from(alice_signature),
+                }],
+                outputs: vec![TransactionOutput {
+                    value: 0, // A 0 value output burns this output forever!
+                    pubkey: H256::from(alice_pub_key),
+                    salt: 0,
+                }],
+            };
+
+            assert!(
+                Utxo::execute(Origin::signed(0), transaction).is_err(),
+                "output value must be nonzero"
+            );
+        });
+    }
+
+    #[test]
+    fn attack_by_overflowing_value() {
+        new_test_ext().execute_with(|| {
+            let alice_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[0];
+            let alice_signature = sp_io::crypto::sr25519_sign(SR25519, &alice_pub_key, &GENESIS_UTXO).unwrap();
+
+            let transaction = Transaction {
+                inputs: vec![TransactionInput {
+                    parent_output: H256::from(GENESIS_UTXO),
+                    signature: H512::from(alice_signature),
+                }],
+                outputs: vec![
+                    TransactionOutput {
+                        value: Value::max_value(),
+                        pubkey:  H256::from(alice_pub_key),
+                        salt: 1,
+                    },
+                    TransactionOutput {
+                        value: 10 as Value, // Attempts to do overflow total output value
+                        pubkey: H256::from(alice_pub_key),
+                        salt: 1,
+                    },
+                ],
+            };
+
+            assert!(
+                Utxo::execute(Origin::signed(0), transaction).is_err(),
+                "output value overflow"
+            );
+        });
+    }
+
+    #[test]
+    fn attack_by_over_spending() {
+        new_test_ext().execute_with(|| {
+            let alice_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[0];
+            let alice_signature = sp_io::crypto::sr25519_sign(SR25519, &alice_pub_key, &GENESIS_UTXO).unwrap();
+
+            let transaction = Transaction {
+                inputs: vec![TransactionInput {
+                    parent_output: H256::from(GENESIS_UTXO),
+                    signature: H512::from(alice_signature),
+                }],
+                outputs: vec![
+                    TransactionOutput {
+                        value: 100 as Value,
+                        pubkey: H256::from(alice_pub_key),
+                        salt: 1,
+                    },
+                    TransactionOutput {
+                        value: 1 as Value, // Creates 1 new utxo out of thin air!
+                        pubkey: H256::from(alice_pub_key),
+                        salt: 1,
+                    },
+                ],
+            };
+
+            assert!(
+                Utxo::execute(Origin::signed(0), transaction).is_err(),
+                "output value must not exceed input value"
+            );
+        });
+    }
 }

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -118,7 +118,7 @@ impl<T: Trait> Module<T> {
     /// Check transaction for validity.
     /// Returns: Remaining reward value for validators
     /// If any errors, runtime execution will halt
-    pub fn check_transaction(_transaction: &Transaction) -> Result<Value, &'static str> {
+    pub fn check_transaction(transaction: &Transaction) -> Result<Value, &'static str> {
         ensure!(!_transaction.inputs.is_empty(), "no inputs");
         ensure!(!_transaction.outputs.is_empty(), "no outputs");
 

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -173,7 +173,7 @@ impl<T: Trait> Module<T> {
             .ok_or("Reward overflow")?;
         <RewardTotal>::put(new_total);
 
-        // Storing updated reward value
+        // Removing spent UTXOs
         for input in &transaction.inputs {
             <UtxoStore>::remove(input.outpoint);
         }

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -238,7 +238,7 @@ impl<T: Trait> Module<T> {
     /// If None missing inputs: no race condition, gtg
     /// if Some(missing inputs): there are missing variables
     pub fn has_race_condition(_transaction: &Transaction) -> Option<Vec<&H256>> {
-        let mut missing_utxo = Vec::new();
+        let mut missing_utxos = Vec::new();
         for input in _transaction.inputs.iter() {
             if !<UtxoStore>::exists(&input.outpoint) {
                 missing_utxo.push(&input.outpoint);

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -49,7 +49,7 @@ pub struct TransactionOutput {
     pub value: Value,
 
     /// Public key associated with this output. In order to spend this output
-	/// owner must provide a proof by hashing whole `TransactionOutput` and
+	/// owner must provide a proof by hashing the whole `Transaction` and
 	/// signing it with a corresponding private key.
     pub pubkey: H256,
 }

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -122,7 +122,7 @@ impl<T: Trait> Module<T> {
         ensure!(!_transaction.inputs.is_empty(), "no inputs");
         ensure!(!_transaction.outputs.is_empty(), "no outputs");
 
-        {
+        { // nested scope so btreemaps resource gets freed
             let input_set: BTreeMap<_, ()> =_transaction.inputs.iter().map(|input| (input, ())).collect();
             ensure!(input_set.len() == _transaction.inputs.len(), "each input must only be used once");
         }
@@ -353,12 +353,12 @@ mod tests {
             
             let alice_signature = sp_io::crypto::sr25519_sign(SR25519, &alice_pub_key, &transaction.encode()).unwrap();
             transaction.inputs[0].sigscript = H512::from(alice_signature);
-            let transaction_hash = BlakeTwo256::hash_of(&(&transaction.encode(), 0 as u64)); 
+            let new_utxo_hash = BlakeTwo256::hash_of(&(&transaction.encode(), 0 as u64)); 
             
             assert_ok!(Utxo::spend(Origin::signed(0), transaction));
             assert!(!UtxoStore::exists(H256::from(GENESIS_UTXO)));
-            assert!(UtxoStore::exists(transaction_hash));
-            assert_eq!(50, UtxoStore::get(transaction_hash).unwrap().value);
+            assert!(UtxoStore::exists(new_utxo_hash));
+            assert_eq!(50, UtxoStore::get(new_utxo_hash).unwrap().value);
         });
     }
 

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -382,9 +382,7 @@ mod tests {
             assert_ok!(Utxo::execute(Origin::signed(0), transaction)); // technically we're signing with an account, that's not the corresponding key
             assert!(!UnspentOutputs::exists(H256::from(GENESIS_UTXO)));
             assert!(UnspentOutputs::exists(transaction_hash));
-            
-            // TODO check bob's utxo value
-            
+            assert_eq!(50, UnspentOutputs::get(transaction_hash).unwrap().value);
         });
     }
 

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -240,7 +240,7 @@ impl<T: Trait> Module<T> {
     pub fn has_race_condition(_transaction: &Transaction) -> Option<Vec<&H256>> {
         let mut missing_utxo = Vec::new();
         for input in _transaction.inputs.iter() {
-            if <UtxoStore>::get(&input.outpoint).is_none() {
+            if !<UtxoStore>::exists(&input.outpoint) {
                 missing_utxo.push(&input.outpoint);
             }
         }

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -182,8 +182,8 @@ impl<T: Trait> Module<T> {
         let index: u64 = 0;
         for output in &transaction.outputs {
             let hash = BlakeTwo256::hash_of(&(&transaction.encode(), index));
-            <UtxoStore>::insert(hash, output);
             index.checked_add(1).ok_or("output index overflow")?;
+            <UtxoStore>::insert(hash, output);
         }
 
         Ok(())

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use sp_core::sr25519::{Public, Signature};
 use sp_runtime::traits::{BlakeTwo256, Hash, SaturatedConversion};
 use sp_std::collections::btree_map::BTreeMap;
+use sp_runtime::transaction_validity::{TransactionLongevity, ValidTransaction};
 
 pub trait Trait: system::Trait {
     type Event: From<Event> + Into<<Self as system::Trait>::Event>;
@@ -84,10 +85,10 @@ decl_module! {
 
         /// Dispatch a single transaction and update UTXO set accordingly
         pub fn spend(_origin, transaction: Transaction) -> DispatchResult {
-
-            let reward = Self::check_transaction(&transaction)?;
-
-            Self::update_storage(&transaction, reward)?;
+                                    // TransactionValidity{}
+            let transaction_validity = Self::validate_transaction(&transaction)?;
+            
+            Self::update_storage(&transaction, transaction_validity.priority as u128)?;
 
             Self::deposit_event(Event::TransactionSuccess(transaction));
 
@@ -115,14 +116,25 @@ decl_event!(
 // "Internal" functions, callable by code.
 impl<T: Trait> Module<T> {
 
-    /// Check transaction for validity.
-    /// Returns: Remaining reward value for validators
-    /// If any errors, runtime execution will halt
-    pub fn check_transaction(transaction: &Transaction) -> Result<Value, &'static str> {
+    /// Check transaction for validity, errors, & race conditions
+    /// Called by both transaction pool and runtime execution
+    /// 
+    /// Ensures that:
+    /// - inputs and outputs are not empty
+    /// - all inputs match to existing, unspent and unlocked outputs
+    /// - each input is used exactly once
+    /// - each output is defined exactly once and has nonzero value
+    /// - total output value must not exceed total input value
+    /// - new outputs do not collide with existing ones
+    /// - sum of input and output values does not overflow
+    /// - provided signatures are valid
+    /// - transaction outputs cannot be modified by malicious nodes
+    pub fn validate_transaction(transaction: &Transaction) -> Result<ValidTransaction, &'static str> {
+        // Check basic requirements
         ensure!(!transaction.inputs.is_empty(), "no inputs");
         ensure!(!transaction.outputs.is_empty(), "no outputs");
 
-        { // nested scope so btreemaps resource gets freed
+        {
             let input_set: BTreeMap<_, ()> =transaction.inputs.iter().map(|input| (input, ())).collect();
             ensure!(input_set.len() == transaction.inputs.len(), "each input must only be used once");
         }
@@ -133,35 +145,52 @@ impl<T: Trait> Module<T> {
 
         let mut total_input: Value = 0;
         let mut total_output: Value = 0;
+        let mut output_index: u64 = 0;
         let simple_transaction = Self::get_simple_transaction(transaction);
 
-        for input in transaction.inputs.iter() {
-            let utxo = <UtxoStore>::get(&input.outpoint).ok_or("missing input utxo")?;
+        // Variables sent to transaction pool
+        let mut missing_utxos = Vec::new();
+        let mut new_utxos = Vec::new();
+        let mut reward = 0;
 
-            ensure!(sp_io::crypto::sr25519_verify(
-                        &Signature::from_raw(*input.sigscript.as_fixed_bytes()),
-                        &simple_transaction,
-                        &Public::from_h256(utxo.pubkey)
-                    ), "signature must be valid"
-            );
-            
-            total_input = total_input.checked_add(utxo.value).ok_or("input value overflow")?;
+        // Check that inputs are valid
+        for input in transaction.inputs.iter() {
+            if let Some(input_utxo) = <UtxoStore>::get(&input.outpoint) {
+                ensure!(sp_io::crypto::sr25519_verify(
+                    &Signature::from_raw(*input.sigscript.as_fixed_bytes()),
+                    &simple_transaction,
+                    &Public::from_h256(input_utxo.pubkey)
+                ), "signature must be valid" );
+                total_input = total_input.checked_add(input_utxo.value).ok_or("input value overflow")?;
+            } else {
+                missing_utxos.push(input.outpoint.clone().as_fixed_bytes().to_vec()); // TODO is clone needed here?
+            }
         }
 
-        let index: u64 = 0;
+        // Check that outputs are valid
         for output in transaction.outputs.iter() {
             ensure!(output.value > 0, "output value must be nonzero");
-            
-            let hash = BlakeTwo256::hash_of(&(&transaction.encode(), index));
-            index.checked_add(1).ok_or("output index overflow")?;
-            
+            let hash = BlakeTwo256::hash_of(&(&transaction.encode(), output_index));
+            output_index = output_index.checked_add(1).ok_or("output index overflow")?;
             ensure!(!<UtxoStore>::exists(hash), "output already exists");
             total_output = total_output.checked_add(output.value).ok_or("output value overflow")?;
+            new_utxos.push(hash.as_fixed_bytes().to_vec());
+        }
+        
+        // If no race condition, check the math
+        if missing_utxos.is_empty() {
+            ensure!( total_input >= total_output, "output value must not exceed input value");
+            reward = total_input.checked_sub(total_output).ok_or("reward underflow")?;
         }
 
-        ensure!( total_input >= total_output, "output value must not exceed input value");
-
-        Ok( total_input.checked_sub(total_output).ok_or("reward underflow")? )
+        // Returns transaction details
+        Ok(ValidTransaction {
+            requires: missing_utxos,
+            provides: new_utxos,
+            priority: reward as u64,
+            longevity: TransactionLongevity::max_value(),
+            propagate: true,
+        })
     }
     
     /// Update storage to reflect changes made by transaction
@@ -178,11 +207,10 @@ impl<T: Trait> Module<T> {
             <UtxoStore>::remove(input.outpoint);
         }
 
-        // Add new UTXOs to be used by future transactions
-        let index: u64 = 0;
+        let mut index: u64 = 0;
         for output in &transaction.outputs {
             let hash = BlakeTwo256::hash_of(&(&transaction.encode(), index));
-            index.checked_add(1).ok_or("output index overflow")?;
+            index = index.checked_add(1).ok_or("output index overflow")?;
             <UtxoStore>::insert(hash, output);
         }
 
@@ -361,30 +389,30 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_race_condition() {
-        new_test_ext().execute_with(|| {
-            let alice_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[0];
-            let nonexistent_utxo = H256::random();
+    // #[test]
+    // fn test_race_condition() {
+    //     new_test_ext().execute_with(|| {
+    //         let alice_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[0];
+    //         let nonexistent_utxo = H256::random();
 
-            let mut transaction = Transaction {
-                inputs: vec![TransactionInput {
-                    outpoint: nonexistent_utxo,
-                    sigscript: H512::zero(),
-                }],
-                outputs: vec![TransactionOutput {
-                    value: 50,
-                    pubkey: H256::from(alice_pub_key),
-                }],
-            };
+    //         let mut transaction = Transaction {
+    //             inputs: vec![TransactionInput {
+    //                 outpoint: nonexistent_utxo,
+    //                 sigscript: H512::zero(),
+    //             }],
+    //             outputs: vec![TransactionOutput {
+    //                 value: 50,
+    //                 pubkey: H256::from(alice_pub_key),
+    //             }],
+    //         };
 
-            let alice_signature = sp_io::crypto::sr25519_sign(SR25519, &alice_pub_key, &transaction.encode()).unwrap();
-            transaction.inputs[0].sigscript = H512::from(alice_signature);
-            let missing_utxo_hash = Utxo::get_missing_utxos(&transaction)[0];
+    //         let alice_signature = sp_io::crypto::sr25519_sign(SR25519, &alice_pub_key, &transaction.encode()).unwrap();
+    //         transaction.inputs[0].sigscript = H512::from(alice_signature);
+    //         let missing_utxo_hash = Utxo::get_missing_utxos(&transaction)[0];
             
-            assert_eq!(missing_utxo_hash.as_fixed_bytes(), nonexistent_utxo.as_fixed_bytes());
-        });
-    }
+    //         assert_eq!(missing_utxo_hash.as_fixed_bytes(), nonexistent_utxo.as_fixed_bytes());
+    //     });
+    // }
 
     // Exercise 1: Fortify transactions against attacks
     // ================================================

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -178,7 +178,7 @@ impl<T: Trait> Module<T> {
             <UtxoStore>::remove(input.outpoint);
         }
 
-        // Add new UTXO to be used by future transactions
+        // Add new UTXOs to be used by future transactions
         let index: u64 = 0;
         for output in &transaction.outputs {
             let hash = BlakeTwo256::hash_of(&(&transaction.encode(), index));

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -117,6 +117,7 @@ impl Alternative {
     }
 }
 
+// Dev mode genesis setup
 fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
     root_key: AccountId,
     endowed_accounts: Vec<AccountId>,

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -128,7 +128,7 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
 
     // This prints when your blockchain starts up for the first time
     println!("============ HELPER INPUTS FOR THE UI DEMO ============");
-    println!("OUTPUT (Alice's UTXO Hash): 0x76584168d10a20084082ed80ec71e2a783abbb8dd6eb9d4893b089228498e9ff\n");
+    println!("OUTPOINT (Alice's UTXO Hash): 0x76584168d10a20084082ed80ec71e2a783abbb8dd6eb9d4893b089228498e9ff\n");
     println!("SIGSCRIPT (Alice Signature on a transaction where she spends 50 utxo on Bob): 0x6ceab99702c60b111c12c2867679c5555c00dcd4d6ab40efa01e3a65083bfb6c6f5c1ed3356d7141ec61894153b8ba7fb413bf1e990ed99ff6dee5da1b24fd83\n");
     println!("PUBKEY (Bob's public key hash): 0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48\n");
     println!("NEW UTXO HASH in UTXOStore onchain: 0xdbc75ab8ee9b83dcbcea4695f9c42754d94e92c3c397d63b1bc627c2a2ef94e6\n");

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -121,30 +121,15 @@ impl Alternative {
 fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
     root_key: AccountId,
     endowed_accounts: Vec<AccountId>,
-    _enable_println: bool) -> GenesisConfig {
+    _enable_println: bool) -> GenesisConfig 
+{
+    // TODO update this per latest sigscript scheme
     let genesis_utxo = utxo::TransactionOutput {
       value: utxo::Value::max_value(),
       pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
       salt: 0,
     };
 
-    println!("Initial UTXO Hash: {:?}", BlakeTwo256::hash_of(&genesis_utxo));
-
-    let txn1 = utxo::TransactionOutput {
-      value: 100,
-      pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Bob").as_slice()),
-      salt: 0,
-    };
-
-    let txn2 = utxo::TransactionOutput {
-      value: utxo::Value::max_value() - 100,
-      pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
-      salt: 0,
-    };
-
-    println!("Transaction #1 {:?}, Hash: {:?}", txn1, BlakeTwo256::hash_of(&txn1));
-    println!("Transaction #2 {:?}, Hash: {:?}", txn2, BlakeTwo256::hash_of(&txn2));
-    
     GenesisConfig {
       system: Some(SystemConfig {
         code: WASM_BINARY.to_vec(),
@@ -170,4 +155,26 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
         genesis_utxo: vec![genesis_utxo],
       }),
     }
+
+    println!("Genesis UTXO Hash: {:?}", BlakeTwo256::hash_of(&genesis_utxo));
+
+    // ----------------------
+    // HELPER PRINT OUTS FOR DEMO PURPOSES
+    // TODO update this per latest sigscript scheme
+    let txn1 = utxo::TransactionOutput {
+      value: 100,
+      pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Bob").as_slice()),
+      salt: 0,
+    };
+
+    // TODO update this per latest sigscript scheme
+    let txn2 = utxo::TransactionOutput {
+      value: utxo::Value::max_value() - 100,
+      pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
+      salt: 0,
+    };
+
+    println!("Transaction #1 {:?}, Hash: {:?}", txn1, BlakeTwo256::hash_of(&txn1));
+    println!("Transaction #2 {:?}, Hash: {:?}", txn2, BlakeTwo256::hash_of(&txn2));
+    // ----------------------
 }

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -123,11 +123,9 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
     endowed_accounts: Vec<AccountId>,
     _enable_println: bool) -> GenesisConfig 
 {
-    // TODO update this per latest sigscript scheme
     let genesis_utxo = utxo::TransactionOutput {
       value: utxo::Value::max_value(),
       pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
-      salt: 0,
     };
 
     GenesisConfig {
@@ -156,22 +154,19 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
       }),
     }
 
-    println!("Genesis UTXO Hash: {:?}", BlakeTwo256::hash_of(&genesis_utxo));
-
     // ----------------------
     // HELPER PRINT OUTS FOR DEMO PURPOSES
-    // TODO update this per latest sigscript scheme
+    println!("Genesis UTXO Hash: {:?}", BlakeTwo256::hash_of(&genesis_utxo));
+
     let txn1 = utxo::TransactionOutput {
       value: 100,
       pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Bob").as_slice()),
-      salt: 0,
     };
 
     // TODO update this per latest sigscript scheme
     let txn2 = utxo::TransactionOutput {
       value: utxo::Value::max_value() - 100,
       pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
-      salt: 0,
     };
 
     println!("Transaction #1 {:?}, Hash: {:?}", txn1, BlakeTwo256::hash_of(&txn1));

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -7,11 +7,10 @@ use utxo_runtime::{
 use sp_consensus_aura::sr25519::{AuthorityId as AuraId};
 use grandpa_primitives::{AuthorityId as GrandpaId};
 use sc_service;
-use sp_runtime::traits::{Verify, IdentifyAccount, BlakeTwo256, Hash};
+use sp_runtime::traits::{Verify, IdentifyAccount};
 
-use primitive_types::{H256, H512};
+use primitive_types::{H256};
 use sp_core::{Pair, Public, sr25519};
-use codec::{Encode};
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::ChainSpec<GenesisConfig>;
@@ -132,7 +131,7 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
     println!("OUTPUT (Alice's UTXO Hash): 0x76584168d10a20084082ed80ec71e2a783abbb8dd6eb9d4893b089228498e9ff\n");
     println!("SIGSCRIPT (Alice Signature on a transaction where she spends 50 utxo on Bob): 0x6ceab99702c60b111c12c2867679c5555c00dcd4d6ab40efa01e3a65083bfb6c6f5c1ed3356d7141ec61894153b8ba7fb413bf1e990ed99ff6dee5da1b24fd83\n");
     println!("PUBKEY (Bob's public key hash): 0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48\n");
-    println!("NEW UTXO HASH in UTXOStore onchain: 0xdbc75ab8ee9b83dcbcea4695f9c42754d94e92c3c397d63b1bc627c2a2ef94e6\n";
+    println!("NEW UTXO HASH in UTXOStore onchain: 0xdbc75ab8ee9b83dcbcea4695f9c42754d94e92c3c397d63b1bc627c2a2ef94e6\n");
         
     GenesisConfig {
       system: Some(SystemConfig {

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -156,20 +156,20 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
 
     // ----------------------
     // HELPER PRINT OUTS FOR DEMO PURPOSES
-    println!("Genesis UTXO Hash: {:?}", BlakeTwo256::hash_of(&genesis_utxo));
+    // println!("Genesis UTXO Hash: {:?}", BlakeTwo256::hash_of(&genesis_utxo));
 
-    let txn1 = utxo::TransactionOutput {
-      value: 100,
-      pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Bob").as_slice()),
-    };
+    // let txn1 = utxo::TransactionOutput {
+    //   value: 100,
+    //   pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Bob").as_slice()),
+    // };
 
-    // TODO update this per latest sigscript scheme
-    let txn2 = utxo::TransactionOutput {
-      value: utxo::Value::max_value() - 100,
-      pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
-    };
+    // // TODO update this per latest sigscript scheme
+    // let txn2 = utxo::TransactionOutput {
+    //   value: utxo::Value::max_value() - 100,
+    //   pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
+    // };
 
-    println!("Transaction #1 {:?}, Hash: {:?}", txn1, BlakeTwo256::hash_of(&txn1));
-    println!("Transaction #2 {:?}, Hash: {:?}", txn2, BlakeTwo256::hash_of(&txn2));
+    // println!("Transaction #1 {:?}, Hash: {:?}", txn1, BlakeTwo256::hash_of(&txn1));
+    // println!("Transaction #2 {:?}, Hash: {:?}", txn2, BlakeTwo256::hash_of(&txn2));
     // ----------------------
 }

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -134,7 +134,7 @@ fn testnet_genesis(
     endowed_utxos: Vec<sr25519::Public>,
     _enable_println: bool) -> GenesisConfig 
 {
-    // This prints when your blockchain starts up for the first time
+    // This prints upon creation of the genesis block
     println!("============ HELPER INPUTS FOR THE UI DEMO ============");
     println!("OUTPOINT (Alice's UTXO Hash): 0x76584168d10a20084082ed80ec71e2a783abbb8dd6eb9d4893b089228498e9ff\n");
     println!("SIGSCRIPT (Alice Signature on a transaction where she spends 50 utxo on Bob): 0x6ceab99702c60b111c12c2867679c5555c00dcd4d6ab40efa01e3a65083bfb6c6f5c1ed3356d7141ec61894153b8ba7fb413bf1e990ed99ff6dee5da1b24fd83\n");

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -1,18 +1,17 @@
-use sp_core::{Pair, Public, sr25519};
+use utxo_runtime::utxo;
 use utxo_runtime::{
     AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig,
     SudoConfig, IndicesConfig, SystemConfig, WASM_BINARY, Signature
 };
+
 use sp_consensus_aura::sr25519::{AuthorityId as AuraId};
 use grandpa_primitives::{AuthorityId as GrandpaId};
 use sc_service;
 use sp_runtime::traits::{Verify, IdentifyAccount, BlakeTwo256, Hash};
 
-use primitive_types::H256;
-use utxo_runtime::utxo;
-
-// Note this is the URL for the telemetry server
-//const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
+use primitive_types::{H256, H512};
+use sp_core::{Pair, Public, sr25519};
+use codec::{Encode};
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::ChainSpec<GenesisConfig>;
@@ -123,11 +122,18 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
     endowed_accounts: Vec<AccountId>,
     _enable_println: bool) -> GenesisConfig 
 {
-    let genesis_utxo = utxo::TransactionOutput {
-      value: utxo::Value::max_value(),
+    let alice_utxo = utxo::TransactionOutput {
+      value: 100 as utxo::Value,
       pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
     };
 
+    // This prints when your blockchain starts up for the first time
+    println!("============ HELPER INPUTS FOR THE UI DEMO ============");
+    println!("OUTPUT (Alice's UTXO Hash): 0x76584168d10a20084082ed80ec71e2a783abbb8dd6eb9d4893b089228498e9ff\n");
+    println!("SIGSCRIPT (Alice Signature on a transaction where she spends 50 utxo on Bob): 0x6ceab99702c60b111c12c2867679c5555c00dcd4d6ab40efa01e3a65083bfb6c6f5c1ed3356d7141ec61894153b8ba7fb413bf1e990ed99ff6dee5da1b24fd83\n");
+    println!("PUBKEY (Bob's public key hash): 0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48\n");
+    println!("NEW UTXO HASH in UTXOStore onchain: 0xdbc75ab8ee9b83dcbcea4695f9c42754d94e92c3c397d63b1bc627c2a2ef94e6\n";
+        
     GenesisConfig {
       system: Some(SystemConfig {
         code: WASM_BINARY.to_vec(),
@@ -150,7 +156,7 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
         authorities: initial_authorities.iter().map(|x| (x.1.clone(), 1)).collect(),
       }),
       utxo: Some(utxo::GenesisConfig {
-        genesis_utxo: vec![genesis_utxo],
+        genesis_utxo: vec![alice_utxo],
       }),
     }
 }

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -153,23 +153,4 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
         genesis_utxo: vec![genesis_utxo],
       }),
     }
-
-    // ----------------------
-    // HELPER PRINT OUTS FOR DEMO PURPOSES
-    // println!("Genesis UTXO Hash: {:?}", BlakeTwo256::hash_of(&genesis_utxo));
-
-    // let txn1 = utxo::TransactionOutput {
-    //   value: 100,
-    //   pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Bob").as_slice()),
-    // };
-
-    // // TODO update this per latest sigscript scheme
-    // let txn2 = utxo::TransactionOutput {
-    //   value: utxo::Value::max_value() - 100,
-    //   pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
-    // };
-
-    // println!("Transaction #1 {:?}, Hash: {:?}", txn1, BlakeTwo256::hash_of(&txn1));
-    // println!("Transaction #2 {:?}, Hash: {:?}", txn2, BlakeTwo256::hash_of(&txn2));
-    // ----------------------
 }

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -122,13 +122,13 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
     root_key: AccountId,
     endowed_accounts: Vec<AccountId>,
     _enable_println: bool) -> GenesisConfig {
-    let initial_utxo = utxo::TransactionOutput {
+    let genesis_utxo = utxo::TransactionOutput {
       value: utxo::Value::max_value(),
       pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
       salt: 0,
     };
 
-    println!("Initial UTXO Hash: {:?}", BlakeTwo256::hash_of(&initial_utxo));
+    println!("Initial UTXO Hash: {:?}", BlakeTwo256::hash_of(&genesis_utxo));
 
     let txn1 = utxo::TransactionOutput {
       value: 100,
@@ -167,7 +167,7 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
         authorities: initial_authorities.iter().map(|x| (x.1.clone(), 1)).collect(),
       }),
       utxo: Some(utxo::GenesisConfig {
-        initial_utxo: vec![initial_utxo],
+        genesis_utxo: vec![genesis_utxo],
       }),
     }
 }

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -57,15 +57,21 @@ impl Alternative {
             Alternative::Development => ChainSpec::from_genesis(
                 "Development",
                 "dev",
-                || testnet_genesis(vec![
+                || testnet_genesis(
+                  vec![
                     get_authority_keys_from_seed("Alice"),
-                ],
+                  ],
                 get_account_id_from_seed::<sr25519::Public>("Alice"),
                 vec![
                     get_account_id_from_seed::<sr25519::Public>("Alice"),
                     get_account_id_from_seed::<sr25519::Public>("Bob"),
                     get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+                ],
+                // Genesis set of pubkeys that own UTXOs
+                vec![
+                    get_from_seed::<sr25519::Public>("Alice"),
+                    get_from_seed::<sr25519::Public>("Bob"),
                 ],
                 true),
                 vec![],
@@ -96,6 +102,11 @@ impl Alternative {
                     get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
                 ],
+                // Genesis set of pubkeys that own UTXOs
+                vec![
+                    get_from_seed::<sr25519::Public>("Alice"),
+                    get_from_seed::<sr25519::Public>("Bob"),
+                ],
                 true),
                 vec![],
                 None,
@@ -116,16 +127,13 @@ impl Alternative {
 }
 
 // Dev mode genesis setup
-fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
+fn testnet_genesis(
+    initial_authorities: Vec<(AuraId, GrandpaId)>,
     root_key: AccountId,
     endowed_accounts: Vec<AccountId>,
+    endowed_utxos: Vec<sr25519::Public>,
     _enable_println: bool) -> GenesisConfig 
 {
-    let alice_utxo = utxo::TransactionOutput {
-      value: 100 as utxo::Value,
-      pubkey: H256::from_slice(get_from_seed::<sr25519::Public>("Alice").as_slice()),
-    };
-
     // This prints when your blockchain starts up for the first time
     println!("============ HELPER INPUTS FOR THE UI DEMO ============");
     println!("OUTPOINT (Alice's UTXO Hash): 0x76584168d10a20084082ed80ec71e2a783abbb8dd6eb9d4893b089228498e9ff\n");
@@ -155,7 +163,14 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
         authorities: initial_authorities.iter().map(|x| (x.1.clone(), 1)).collect(),
       }),
       utxo: Some(utxo::GenesisConfig {
-        genesis_utxo: vec![alice_utxo],
+        genesis_utxos: endowed_utxos
+                      .iter()
+                      .map(|x|
+                        utxo::TransactionOutput {
+                          value: 100 as utxo::Value,
+                          pubkey: H256::from_slice(x.as_slice()),
+                      })
+                      .collect()
       }),
     }
 }


### PR DESCRIPTION
Resolves issue #37 

Includes: 
- Better test setup: uses testing::keystone to manage keys signing utxos, rather than hardcoded key values
- Better unit test checking "execute" extrinsic
- General cleanup
- All tests passing