### PR TITLE
Remove session keys from runtimes

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,7 +14,6 @@ use sp_runtime::{
 	ApplyExtrinsicResult,
 	create_runtime_str,
 	generic,
-	impl_opaque_keys,
 	MultiSignature,
 	traits::{
 		BlakeTwo256,
@@ -100,10 +99,6 @@ pub mod opaque {
 	pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 	/// Opaque block identifier type.
 	pub type BlockId = generic::BlockId<Block>;
-
-	impl_opaque_keys! {
-		pub struct SessionKeys {}
-	}
 }
 
 /// This runtime version.
@@ -352,14 +347,14 @@ impl_runtime_apis! {
 	}
 
 	impl sp_session::SessionKeys<Block> for Runtime {
-		fn generate_session_keys(seed: Option<Vec<u8>>) -> Vec<u8> {
-			opaque::SessionKeys::generate(seed)
+		fn generate_session_keys(_seed: Option<Vec<u8>>) -> Vec<u8> {
+			Vec::new()
 		}
 
 		fn decode_session_keys(
-			encoded: Vec<u8>,
+			_encoded: Vec<u8>,
 		) -> Option<Vec<(Vec<u8>, sp_core::crypto::KeyTypeId)>> {
-			opaque::SessionKeys::decode_into_raw_public_keys(&encoded)
+			None
 		}
 	}
 


### PR DESCRIPTION
Thanks to @bkchr I figured out how we can clean up the no-longer-necessary session keys stuff from the runtime.