### PR TITLE
Fix missing input bug

### DIFF
--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -447,7 +447,7 @@ mod tests {
 			// Karl wants to send himself a new utxo of value 50 out of thin air.
 			let mut transaction = Transaction {
 				inputs: vec![TransactionInput {
-					outpoint: H256::from(karl_pub_key),
+					outpoint: H256::zero(),
 					sigscript: H512::zero(),
 				}],
 				outputs: vec![TransactionOutput {

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -343,6 +343,8 @@ mod tests {
 	use hex_literal::hex;
 
 	const ALICE_PHRASE: &str = "news slush supreme milk chapter athlete soap sausage put clutch what kitten";
+	// other random account generated with subkey
+	const KARL_PHRASE: &str = "monitor exhibit resource stumble subject nut valid furnace obscure misery satoshi assume";
 	const GENESIS_UTXO: [u8; 32] = hex!("79eabcbd5ef6e958c6a7851b36da07691c19bda1835a08f875aa286911800999");
 
 	// This function basically just builds a genesis storage key/value store according to our desired mockup.
@@ -351,6 +353,7 @@ mod tests {
 
 		let keystore = KeyStore::new(); // a key storage to store new key pairs during testing
 		let alice_pub_key = keystore.write().sr25519_generate_new(SR25519, Some(ALICE_PHRASE)).unwrap();
+		let karl_pub_key = keystore.write().sr25519_generate_new(SR25519, Some(KARL_PHRASE)).unwrap();
 
 		let mut t = frame_system::GenesisConfig::default()
 			.build_storage::<Test>()
@@ -400,6 +403,34 @@ mod tests {
 
 			assert_ok!(Utxo::spend(Origin::signed(0), transaction));
 			assert!(!UtxoStore::contains_key(H256::from(GENESIS_UTXO)));
+			assert!(UtxoStore::contains_key(new_utxo_hash));
+			assert_eq!(50, UtxoStore::get(new_utxo_hash).unwrap().value);
+		});
+	}
+
+	#[test]
+	fn attack_with_missing_account() {
+		new_test_ext().execute_with(|| {
+			let alice_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[0];
+			let karl_pub_key = sp_io::crypto::sr25519_public_keys(SR25519)[1];
+
+			// Alice wants to send herself a new utxo of value 50.
+			let mut transaction = Transaction {
+				inputs: vec![TransactionInput {
+					outpoint: H256::from(karl_pub_key),
+					sigscript: H512::zero(),
+				}],
+				outputs: vec![TransactionOutput {
+					value: 50,
+					pubkey: H256::from(alice_pub_key),
+				}],
+			};
+
+			let alice_signature = sp_io::crypto::sr25519_sign(SR25519, &alice_pub_key, &transaction.encode()).unwrap();
+			transaction.inputs[0].sigscript = H512::from(alice_signature);
+			let new_utxo_hash = BlakeTwo256::hash_of(&(&transaction.encode(), 0 as u64));
+
+			assert_ok!(Utxo::spend(Origin::signed(0), transaction));
 			assert!(UtxoStore::contains_key(new_utxo_hash));
 			assert_eq!(50, UtxoStore::get(new_utxo_hash).unwrap().value);
 		});

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -439,32 +439,6 @@ mod tests {
 		});
 	}
 
-	#[test]
-	fn attack_with_missing_account() {
-		let (mut test_ext, alice_pub_key, karl_pub_key) = new_test_ext_and_keys();
-		test_ext.execute_with(|| {
-			// Construct a transaction that consumes a bogus input, and sends 50 tokens to Alice.
-			let mut transaction = Transaction {
-				inputs: vec![TransactionInput {
-					// @apopiak outpoint is supposed to be a utxo hash, not a pubkey.
-					// Karl's key works because it happens to be the same number of bits.
-					outpoint: H256::from(karl_pub_key),
-					sigscript: H512::zero(),
-				}],
-				outputs: vec![TransactionOutput {
-					value: 50,
-					pubkey: H256::from(alice_pub_key),
-				}],
-			};
-
-			// Alice signs the transaction
-			let alice_signature = sp_io::crypto::sr25519_sign(SR25519, &alice_pub_key, &transaction.encode()).unwrap();
-			transaction.inputs[0].sigscript = H512::from(alice_signature);
-
-
-			assert_noop!(Utxo::spend(Origin::signed(0), transaction), "missing inputs");
-		});
-	}
 
 	#[test]
 	fn attack_with_sending_to_own_account() {

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -105,6 +105,7 @@ decl_module! {
 		pub fn spend(_origin, transaction: Transaction) -> DispatchResult {
 									// TransactionValidity{}
 			let transaction_validity = Self::validate_transaction(&transaction)?;
+			ensure!(transaction_validity.requires.is_empty(), "missing inputs");
 
 			Self::update_storage(&transaction, transaction_validity.priority as Value)?;
 

--- a/runtime/src/utxo.rs
+++ b/runtime/src/utxo.rs
@@ -483,11 +483,8 @@ mod tests {
 
 			let karl_signature = sp_io::crypto::sr25519_sign(SR25519, &karl_pub_key, &transaction.encode()).unwrap();
 			transaction.inputs[0].sigscript = H512::from(karl_signature);
-			let new_utxo_hash = BlakeTwo256::hash_of(&(&transaction.encode(), 0 as u64));
 
-			assert_ok!(Utxo::spend(Origin::signed(0), transaction));
-			assert!(UtxoStore::contains_key(new_utxo_hash));
-			assert_eq!(50, UtxoStore::get(new_utxo_hash).unwrap().value);
+			assert_noop!(Utxo::spend(Origin::signed(0), transaction), "missing inputs");
 		});
 	}
 


### PR DESCRIPTION
This PR fixes the issue that the runtime accepts transactions that consume bogus inputs.

While the transaction pool was able successfully filter those transactions, the tx pool cannot be relied on because it is offchain logic. An attacker could program their node to accept these transactions, and the runtime must still be able to defent itself in this case.